### PR TITLE
Open current List

### DIFF
--- a/client/pages/notes/my-notes/index.tsx
+++ b/client/pages/notes/my-notes/index.tsx
@@ -22,6 +22,7 @@ interface Props {
 }
 
 // TODO: 
+// - Open currentList after new notes page - Attach url query with listid, search getAllNotesLists.
 // - Page for updating notes. 
 
 const MyNotes = ({ }) => {
@@ -34,6 +35,15 @@ const MyNotes = ({ }) => {
    const [result] = useGetAllNotesListsQuery()
 
    useIsAuth(result)
+
+   useEffect(() => {
+      // Show the currentList after visiting new-notes page.
+      const listId = router.query.listId
+      if (listId && result.data) {
+         const list: NotesList = result.data.getAllNotesLists.find((list: NotesList) => list.id === listId) as NotesList
+         setCurrentList(list)
+      }
+   }, [router, result])
 
    return (
       <>

--- a/client/pages/notes/my-notes/new-note.tsx
+++ b/client/pages/notes/my-notes/new-note.tsx
@@ -73,7 +73,7 @@ const NewNote = ({ }) => {
                   </FormErrorMessage>
                </FormControl>
 
-               <NextLink href={'/notes/my-notes'}>
+               <NextLink href={`/notes/my-notes?listId=${router.query.listId}`}>
                   <Button
                      colorScheme="teal"
                      mr="1%"


### PR DESCRIPTION
When navigating back to 'my-notes' page from 'new-note' page, open the selected list.

This is achieved by attaching a query parameter to the URL when navigating back to 'my-notes' page,  which stores the current list's id.